### PR TITLE
Change Input hint argument from strings to identifiers

### DIFF
--- a/src/juvix_hint_processor/hint_processor.rs
+++ b/src/juvix_hint_processor/hint_processor.rs
@@ -69,8 +69,8 @@ impl JuvixHintProcessor {
             };
 
         vm.insert_value(vm.get_ap(), memory_exec_scope.next_address)?;
-
         memory_exec_scope.next_address.offset += size;
+
         Ok(())
     }
 

--- a/tests/input1.json
+++ b/tests/input1.json
@@ -205,7 +205,7 @@
                     "__main__",
                     "__main__.main"
                 ],
-                "code": "Input('abba')",
+                "code": "Input(abba)",
                 "flow_tracking_data": {
                     "ap_tracking": {
                         "group": 2,

--- a/tests/input2.json
+++ b/tests/input2.json
@@ -302,7 +302,7 @@
                     "__main__",
                     "__main__.main"
                 ],
-                "code": "Input('X')",
+                "code": "Input(X)",
                 "flow_tracking_data": {
                     "ap_tracking": {
                         "group": 2,
@@ -320,7 +320,7 @@
                     "__main__",
                     "__main__.main"
                 ],
-                "code": "Input('Y')",
+                "code": "Input(Y)",
                 "flow_tracking_data": {
                     "ap_tracking": {
                         "group": 2,


### PR DESCRIPTION
Use `Input(variable)` instead of `Input("variable")`.
