### PR TITLE
Set `cairo-vm` dependency to a specific commit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.0"
 edition = "2021"
 
 [dependencies]
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", version="1.0.0-rc1", features = ["std"] }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm.git", rev="4b17118", features = ["std"] }
 mimalloc = { version = "0.1.37", default-features = false, optional = true }
 clap = { version = "4.3.10", features = ["derive"] }
 thiserror = { version = "1.0.40" }


### PR DESCRIPTION
This prevents things from breaking on upstream updates. Also enables manual CI trigger.
